### PR TITLE
Improved compatability by using long form open and echo tags.

### DIFF
--- a/wp-change-domain.php
+++ b/wp-change-domain.php
@@ -395,7 +395,7 @@ if($is_authenticated) {
                         var seconds_elem = document.getElementById('seconds');
                         var bar_elem     = document.getElementById('bar');
                         var seconds      = parseInt(seconds_elem.innerHTML);
-                        var percentage   = Math.round(seconds / <?= DDWPDC_COOKIE_LIFETIME + 5; ?> * 100);
+                        var percentage   = Math.round(seconds / <?php echo DDWPDC_COOKIE_LIFETIME + 5; ?> * 100);
                         var bar_color    = '#00FF19';
                         if(percentage < 25) {
                             bar_color = 'red';
@@ -435,12 +435,12 @@ if($is_authenticated) {
         <div class="body">
             <?php if($is_authenticated): ?>
                 <div id="timeout">
-                    <div>You have <span id="seconds"><?= ((int) $_COOKIE[DDWPDC_COOKIE_NAME_EXPIRE] + 5) - time();?></span> Seconds left in this session.</div>
+                    <div>You have <span id="seconds"><?php echo ((int) $_COOKIE[DDWPDC_COOKIE_NAME_EXPIRE] + 5) - time(); ?></span> Seconds left in this session.</div>
                     <div id="bar"></div>
                 </div>
                 <div class="clear"></div>
                 <div id="left">
-                    <form method="post" action="<?= basename(__FILE__);?>">
+                    <form method="post" action="<?php echo basename(__FILE__); ?>">
                         <h3>Database Connection Settings</h3>
                         <blockquote>
                             <?php
@@ -448,48 +448,48 @@ if($is_authenticated) {
                             if($DDWPDC->isConfigLoaded()) $DDWPDC->actions[] = 'Attempting to auto-detect form field values.';
                             ?>
                             <label for="host">Host</label>
-                            <div><input type="text" id="host" name="host" value="<?= $DDWPDC->getConfigConstant('DB_HOST'); ?>" /></div>
+                            <div><input type="text" id="host" name="host" value="<?php echo $DDWPDC->getConfigConstant('DB_HOST'); ?>" /></div>
 
                             <label for="username">User</label>
-                            <div><input type="text" id="username" name="username" value="<?= $DDWPDC->getConfigConstant('DB_USER'); ?>" /></div>
+                            <div><input type="text" id="username" name="username" value="<?php echo $DDWPDC->getConfigConstant('DB_USER'); ?>" /></div>
 
                             <label for="password">Password</label>
-                            <div><input type="text" id="password" name="password" value="<?= $DDWPDC->getConfigConstant('DB_PASSWORD'); ?>" /></div>
+                            <div><input type="text" id="password" name="password" value="<?php echo $DDWPDC->getConfigConstant('DB_PASSWORD'); ?>" /></div>
 
                             <label for="database">Database Name</label>
-                            <div><input type="text" id="database" name="database" value="<?= $DDWPDC->getConfigConstant('DB_NAME'); ?>" /></div>
+                            <div><input type="text" id="database" name="database" value="<?php echo $DDWPDC->getConfigConstant('DB_NAME'); ?>" /></div>
 
                             <label for="prefix">Table Prefix</label>
-                            <div><input type="text" id="prefix" name="prefix" value="<?= $DDWPDC->getConfigTablePrefix(); ?>" /></div>
+                            <div><input type="text" id="prefix" name="prefix" value="<?php echo $DDWPDC->getConfigTablePrefix(); ?>" /></div>
                         </blockquote>
 
                         <label for="old_domain">Old Domain</label>
-                        <div>http://<input type="text" id="old_domain" name="old_domain" value="<?= $DDWPDC->getOldDomain(); ?>" /></div>
+                        <div>http://<input type="text" id="old_domain" name="old_domain" value="<?php echo $DDWPDC->getOldDomain(); ?>" /></div>
 
                         <label for="new_domain">New Domain</label>
-                        <div>http://<input type="text" id="new_domain" name="new_domain" value="<?= $DDWPDC->getNewDomain(); ?>" /></div>
+                        <div>http://<input type="text" id="new_domain" name="new_domain" value="<?php echo $DDWPDC->getNewDomain(); ?>" /></div>
 
                         <input type="submit" id="submit_button" name="submit_button" value="Change Domain!" />
                     </form>
                 </div>
                 <div id="right">
-                    <?php if(count($DDWPDC->errors) > 0): foreach($DDWPDC->errors as $error):?>
-                        <div class="log error"><strong>Error:</strong> <?=$error;?></div>
+                    <?php if(count($DDWPDC->errors) > 0): foreach($DDWPDC->errors as $error): ?>
+                        <div class="log error"><strong>Error:</strong> <?php echo $error; ?></div>
                     <?php endforeach; endif; ?>
 
-                    <?php if(count($DDWPDC->notices) > 0): foreach($DDWPDC->notices as $notice):?>
-                        <div class="log notice"><strong>Notice:</strong> <?=$notice;?></div>
+                    <?php if(count($DDWPDC->notices) > 0): foreach($DDWPDC->notices as $notice): ?>
+                        <div class="log notice"><strong>Notice:</strong> <?php echo $notice; ?></div>
                     <?php endforeach; endif; ?>
 
-                    <?php if(count($DDWPDC->actions) > 0): foreach($DDWPDC->actions as $action):?>
-                        <div class="log action"><strong>Action: </strong><?=$action;?></div>
+                    <?php if(count($DDWPDC->actions) > 0): foreach($DDWPDC->actions as $action): ?>
+                        <div class="log action"><strong>Action: </strong><?php echo $action; ?></div>
                     <?php endforeach; endif; ?>
                 </div>
             <?php else: ?>
-                <?if(isset($_POST['auth_password'])):?>
+                <?php if(isset($_POST['auth_password'])): ?>
                     <div class="log error"><strong>Error:</strong> Incorrect password, please try again.</div>
-                <?endif;?>
-                <form id="login" name="login" method="post" action="<?= basename(__FILE__);?>">
+                <?php endif; ?>
+                <form id="login" name="login" method="post" action="<?php echo basename(__FILE__); ?>">
                     <h3>Authenticate</h3>
                     <label for="auth_password">Password</label>
                     <input type="password" id="auth_password" name="auth_password" value="" />


### PR DESCRIPTION
This was done to make the code compatible on all servers, including
those with "short_open_tag" turned off in php.ini.  The short echo
syntax (i.e. "<?=") also does not work when short codes are disabled in
versions of PHP prior to 5.4.0.  This was the default environment on a
popular web host I use, so I was unable to use this script without these
changes, which shouldn't have any negative impact on any environment.  I
also made changes to the spacing before a few end tags to make things
consistent throughout the script.
