### PR TITLE
Pull request to fix issue with semicolon in serialized data

### DIFF
--- a/wp-change-domain.php
+++ b/wp-change-domain.php
@@ -183,7 +183,7 @@ class DDWordPressDomainChanger {
             for($i=0;$i<$match_count;$i++) {
                 $new_string = str_replace($find, $replace, $matches[2][$i], $replace_count);
                 $new_length = ((int) $matches[1][$i]) + ($length_diff * $replace_count);
-                $haystack = str_replace($matches[0][$i], 's:'.$new_length.':"'.$new_string.'"', $haystack);
+                $haystack = str_replace($matches[0][$i], 's:'.$new_length.':"'.$new_string.'";', $haystack);
             }
         }
         return $haystack;


### PR DESCRIPTION
As reported in an issue, serialized data was getting replaced and not followed up by the appropriate semicolon. This should take care of that.  The issue in question:

https://github.com/veloper/WordPress-Domain-Changer/issues/9

Please test and commit when ready.
